### PR TITLE
feat: create multiple iam roles and attach them to the redshift cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ tags:
 | Name | Value | Exported |
 | ---- | ----- | -------- |
 | RedshiftClusterEndpoint | Endpoint.Address | true
-| IamRoleArns | iam_role_arns | false
+| IamRoleArns | iam_role_arns | true
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ tags:
 | Name | Value | Exported |
 | ---- | ----- | -------- |
 | RedshiftClusterEndpoint | Endpoint.Address | true
+| IamRoleArns | iam_role_arns | false
 
 ## Development
 

--- a/redshift.cfndsl.rb
+++ b/redshift.cfndsl.rb
@@ -86,6 +86,7 @@ CloudFormation do
 
   Output("IamRoleArns") {
     Value FnJoin(',', iam_role_arns)
+    Export FnSub("${EnvironmentName}-#{external_parameters[:component_name]}-redshift-iam-role-arns")
   }
 
   security_group_rules = external_parameters.fetch(:security_group_rules, [])

--- a/redshift.cfndsl.rb
+++ b/redshift.cfndsl.rb
@@ -77,7 +77,7 @@ CloudFormation do
       AssumeRolePolicyDocument service_assume_role_policy(['redshift','glue'])
       Policies iam_role_policies(iam_policies[k])
       if v && v.has_key?("name")
-        RoleName v["name"]
+        RoleName FnSub(v["name"])
       end
     }
 

--- a/redshift.cfndsl.rb
+++ b/redshift.cfndsl.rb
@@ -72,13 +72,14 @@ CloudFormation do
 
   iam_role_arns << FnGetAtt(:RedshiftIAMRole, "Arn")
 
-  external_parameters.fetch(:additional_iam_roles, []).each do |iam_role|
-    IAM_Role(iam_role) {
+  external_parameters.fetch(:additional_iam_roles, {}).each do |k,v|
+    IAM_Role(k) {
       AssumeRolePolicyDocument service_assume_role_policy(['redshift','glue'])
-      Policies iam_role_policies(iam_policies[iam_role])
+      Policies iam_role_policies(iam_policies[k])
+      RoleName v["name"]
     }
 
-    iam_role_arns << FnGetAtt(iam_role, "Arn")
+    iam_role_arns << FnGetAtt(k, "Arn")
   end
 
   Output("IamRoleArns") {

--- a/redshift.cfndsl.rb
+++ b/redshift.cfndsl.rb
@@ -72,7 +72,7 @@ CloudFormation do
 
   iam_role_arns << FnGetAtt(:RedshiftIAMRole, "Arn")
 
-  external_parameters.fetch(:additional_iam_roles, []).each_with_index do |iam_role,_|
+  external_parameters.fetch(:additional_iam_roles, []).each do |iam_role|
     IAM_Role(iam_role) {
       AssumeRolePolicyDocument service_assume_role_policy(['redshift','glue'])
       Policies iam_role_policies(iam_policies[iam_role])

--- a/redshift.cfndsl.rb
+++ b/redshift.cfndsl.rb
@@ -76,7 +76,9 @@ CloudFormation do
     IAM_Role(k) {
       AssumeRolePolicyDocument service_assume_role_policy(['redshift','glue'])
       Policies iam_role_policies(iam_policies[k])
-      RoleName v["name"]
+      if v && v.has_key?("name")
+        RoleName v["name"]
+      end
     }
 
     iam_role_arns << FnGetAtt(k, "Arn")

--- a/redshift.cfndsl.rb
+++ b/redshift.cfndsl.rb
@@ -81,6 +81,11 @@ CloudFormation do
       end
     }
 
+    Output("#{k}IamRoleArn") {
+      Value FnGetAtt(k, "Arn")
+      Export FnSub("${EnvironmentName}-#{external_parameters[:component_name]}-redshift-#{k}-iam-role-arn")
+    }
+
     iam_role_arns << FnGetAtt(k, "Arn")
   end
 

--- a/spec/multiple_iam_roles_spec.rb
+++ b/spec/multiple_iam_roles_spec.rb
@@ -72,8 +72,8 @@ describe 'compiled component redshift' do
       
     end
     
-    context "a" do
-      let(:resource) { template["Resources"]["a"] }
+    context "RedshiftCopyUnload" do
+      let(:resource) { template["Resources"]["RedshiftCopyUnload"] }
 
       it "is of type AWS::IAM::Role" do
           expect(resource["Type"]).to eq("AWS::IAM::Role")
@@ -85,12 +85,16 @@ describe 'compiled component redshift' do
       
       it "to have property Policies" do
           expect(resource["Properties"]["Policies"]).to eq([{"PolicyName"=>"logs", "PolicyDocument"=>{"Statement"=>[{"Sid"=>"logs", "Action"=>["logs:*"], "Resource"=>["*"], "Effect"=>"Allow"}]}}])
+      end
+      
+      it "to have property RoleName" do
+          expect(resource["Properties"]["RoleName"]).to eq("dl-uat-RedshiftCopyUnload")
       end
       
     end
     
-    context "b" do
-      let(:resource) { template["Resources"]["b"] }
+    context "MyOtherRole" do
+      let(:resource) { template["Resources"]["MyOtherRole"] }
 
       it "is of type AWS::IAM::Role" do
           expect(resource["Type"]).to eq("AWS::IAM::Role")
@@ -102,6 +106,10 @@ describe 'compiled component redshift' do
       
       it "to have property Policies" do
           expect(resource["Properties"]["Policies"]).to eq([{"PolicyName"=>"logs", "PolicyDocument"=>{"Statement"=>[{"Sid"=>"logs", "Action"=>["logs:*"], "Resource"=>["*"], "Effect"=>"Allow"}]}}])
+      end
+      
+      it "to have property RoleName" do
+          expect(resource["Properties"]["RoleName"]).to eq("myotherrole")
       end
       
     end
@@ -279,7 +287,7 @@ describe 'compiled component redshift' do
       end
       
       it "to have property IamRoles" do
-          expect(resource["Properties"]["IamRoles"]).to eq([{"Fn::GetAtt"=>["RedshiftIAMRole", "Arn"]}, {"Fn::GetAtt"=>["a", "Arn"]}, {"Fn::GetAtt"=>["b", "Arn"]}])
+          expect(resource["Properties"]["IamRoles"]).to eq([{"Fn::GetAtt"=>["RedshiftIAMRole", "Arn"]}, {"Fn::GetAtt"=>["RedshiftCopyUnload", "Arn"]}, {"Fn::GetAtt"=>["MyOtherRole", "Arn"]}])
       end
       
       it "to have property SnapshotIdentifier" do

--- a/spec/multiple_iam_roles_spec.rb
+++ b/spec/multiple_iam_roles_spec.rb
@@ -108,10 +108,6 @@ describe 'compiled component redshift' do
           expect(resource["Properties"]["Policies"]).to eq([{"PolicyName"=>"logs", "PolicyDocument"=>{"Statement"=>[{"Sid"=>"logs", "Action"=>["logs:*"], "Resource"=>["*"], "Effect"=>"Allow"}]}}])
       end
       
-      it "to have property RoleName" do
-          expect(resource["Properties"]["RoleName"]).to eq("myotherrole")
-      end
-      
     end
     
     context "RedshiftSecurityGroup" do

--- a/spec/multiple_iam_roles_spec.rb
+++ b/spec/multiple_iam_roles_spec.rb
@@ -1,0 +1,301 @@
+require 'yaml'
+
+describe 'compiled component redshift' do
+  
+  context 'cftest' do
+    it 'compiles test' do
+      expect(system("cfhighlander cftest #{@validate} --tests tests/multiple_iam_roles.test.yaml")).to be_truthy
+    end      
+  end
+  
+  let(:template) { YAML.load_file("#{File.dirname(__FILE__)}/../out/tests/multiple_iam_roles/redshift.compiled.yaml") }
+  
+  context "Resource" do
+
+    
+    context "RedshiftLoggingS3Bucket" do
+      let(:resource) { template["Resources"]["RedshiftLoggingS3Bucket"] }
+
+      it "is of type AWS::S3::Bucket" do
+          expect(resource["Type"]).to eq("AWS::S3::Bucket")
+      end
+      
+      it "to have property BucketName" do
+          expect(resource["Properties"]["BucketName"]).to eq({"Fn::Join"=>["-", ["redshift", "logs", {"Ref"=>"EnvironmentName"}, {"Ref"=>"AWS::Region"}, {"Fn::Select"=>[4, {"Fn::Split"=>["-", {"Fn::Select"=>[2, {"Fn::Split"=>["/", {"Ref"=>"AWS::StackId"}]}]}]}]}]]})
+      end
+      
+      it "to have property BucketEncryption" do
+          expect(resource["Properties"]["BucketEncryption"]).to eq({"ServerSideEncryptionConfiguration"=>[{"ServerSideEncryptionByDefault"=>{"SSEAlgorithm"=>"AES256"}}]})
+      end
+      
+      it "to have property PublicAccessBlockConfiguration" do
+          expect(resource["Properties"]["PublicAccessBlockConfiguration"]).to eq({"BlockPublicAcls"=>true, "BlockPublicPolicy"=>true, "IgnorePublicAcls"=>true, "RestrictPublicBuckets"=>true})
+      end
+      
+      it "to have property Tags" do
+          expect(resource["Properties"]["Tags"]).to eq([{"Key"=>"Environment", "Value"=>{"Ref"=>"EnvironmentName"}}])
+      end
+      
+    end
+    
+    context "RedshiftLoggingS3BucketPolicy" do
+      let(:resource) { template["Resources"]["RedshiftLoggingS3BucketPolicy"] }
+
+      it "is of type AWS::S3::BucketPolicy" do
+          expect(resource["Type"]).to eq("AWS::S3::BucketPolicy")
+      end
+      
+      it "to have property Bucket" do
+          expect(resource["Properties"]["Bucket"]).to eq({"Ref"=>"RedshiftLoggingS3Bucket"})
+      end
+      
+      it "to have property PolicyDocument" do
+          expect(resource["Properties"]["PolicyDocument"]).to eq({"Statement"=>[{"Principal"=>{"Service"=>"redshift.amazonaws.com"}, "Action"=>["s3:PutObject", "s3:GetBucketAcl"], "Effect"=>"Allow", "Resource"=>[{"Fn::Sub"=>"arn:aws:s3:::${RedshiftLoggingS3Bucket}"}, {"Fn::Sub"=>"arn:aws:s3:::${RedshiftLoggingS3Bucket}/*"}]}]})
+      end
+      
+    end
+    
+    context "RedshiftIAMRole" do
+      let(:resource) { template["Resources"]["RedshiftIAMRole"] }
+
+      it "is of type AWS::IAM::Role" do
+          expect(resource["Type"]).to eq("AWS::IAM::Role")
+      end
+      
+      it "to have property AssumeRolePolicyDocument" do
+          expect(resource["Properties"]["AssumeRolePolicyDocument"]).to eq({"Version"=>"2012-10-17", "Statement"=>[{"Effect"=>"Allow", "Principal"=>{"Service"=>"redshift.amazonaws.com"}, "Action"=>"sts:AssumeRole"}, {"Effect"=>"Allow", "Principal"=>{"Service"=>"glue.amazonaws.com"}, "Action"=>"sts:AssumeRole"}]})
+      end
+      
+      it "to have property Policies" do
+          expect(resource["Properties"]["Policies"]).to eq([{"PolicyName"=>"s3-logging", "PolicyDocument"=>{"Statement"=>[{"Sid"=>"s3logging", "Action"=>["s3:GetBucketLocation", "s3:GetObject", "s3:ListMultipartUploadParts", "s3:ListBucket", "s3:ListBucketMultipartUploads"], "Resource"=>[{"Fn::Sub"=>"arn:aws:s3:::${RedshiftLoggingS3Bucket}"}, {"Fn::Sub"=>"arn:aws:s3:::${RedshiftLoggingS3Bucket}/*"}], "Effect"=>"Allow"}]}}, {"PolicyName"=>"glue", "PolicyDocument"=>{"Statement"=>[{"Sid"=>"glue", "Action"=>["glue:CreateDatabase", "glue:DeleteDatabase", "glue:GetDatabase", "glue:GetDatabases", "glue:UpdateDatabase", "glue:CreateTable", "glue:DeleteTable", "glue:BatchDeleteTable", "glue:UpdateTable", "glue:GetTable", "glue:GetTables", "glue:BatchCreatePartition", "glue:CreatePartition", "glue:DeletePartition", "glue:BatchDeletePartition", "glue:UpdatePartition", "glue:GetPartition", "glue:GetPartitions", "glue:BatchGetPartition"], "Resource"=>["*"], "Effect"=>"Allow"}]}}, {"PolicyName"=>"logs", "PolicyDocument"=>{"Statement"=>[{"Sid"=>"logs", "Action"=>["logs:*"], "Resource"=>["*"], "Effect"=>"Allow"}]}}])
+      end
+      
+    end
+    
+    context "a" do
+      let(:resource) { template["Resources"]["a"] }
+
+      it "is of type AWS::IAM::Role" do
+          expect(resource["Type"]).to eq("AWS::IAM::Role")
+      end
+      
+      it "to have property AssumeRolePolicyDocument" do
+          expect(resource["Properties"]["AssumeRolePolicyDocument"]).to eq({"Version"=>"2012-10-17", "Statement"=>[{"Effect"=>"Allow", "Principal"=>{"Service"=>"redshift.amazonaws.com"}, "Action"=>"sts:AssumeRole"}, {"Effect"=>"Allow", "Principal"=>{"Service"=>"glue.amazonaws.com"}, "Action"=>"sts:AssumeRole"}]})
+      end
+      
+      it "to have property Policies" do
+          expect(resource["Properties"]["Policies"]).to eq([{"PolicyName"=>"logs", "PolicyDocument"=>{"Statement"=>[{"Sid"=>"logs", "Action"=>["logs:*"], "Resource"=>["*"], "Effect"=>"Allow"}]}}])
+      end
+      
+    end
+    
+    context "b" do
+      let(:resource) { template["Resources"]["b"] }
+
+      it "is of type AWS::IAM::Role" do
+          expect(resource["Type"]).to eq("AWS::IAM::Role")
+      end
+      
+      it "to have property AssumeRolePolicyDocument" do
+          expect(resource["Properties"]["AssumeRolePolicyDocument"]).to eq({"Version"=>"2012-10-17", "Statement"=>[{"Effect"=>"Allow", "Principal"=>{"Service"=>"redshift.amazonaws.com"}, "Action"=>"sts:AssumeRole"}, {"Effect"=>"Allow", "Principal"=>{"Service"=>"glue.amazonaws.com"}, "Action"=>"sts:AssumeRole"}]})
+      end
+      
+      it "to have property Policies" do
+          expect(resource["Properties"]["Policies"]).to eq([{"PolicyName"=>"logs", "PolicyDocument"=>{"Statement"=>[{"Sid"=>"logs", "Action"=>["logs:*"], "Resource"=>["*"], "Effect"=>"Allow"}]}}])
+      end
+      
+    end
+    
+    context "RedshiftSecurityGroup" do
+      let(:resource) { template["Resources"]["RedshiftSecurityGroup"] }
+
+      it "is of type AWS::EC2::SecurityGroup" do
+          expect(resource["Type"]).to eq("AWS::EC2::SecurityGroup")
+      end
+      
+      it "to have property GroupDescription" do
+          expect(resource["Properties"]["GroupDescription"]).to eq({"Fn::Sub"=>"${EnvironmentName} - Redshift cluster security group"})
+      end
+      
+      it "to have property VpcId" do
+          expect(resource["Properties"]["VpcId"]).to eq({"Ref"=>"VpcId"})
+      end
+      
+      it "to have property Tags" do
+          expect(resource["Properties"]["Tags"]).to eq([{"Key"=>"Environment", "Value"=>{"Ref"=>"EnvironmentName"}}])
+      end
+      
+    end
+    
+    context "SecretRedshiftMasterUser" do
+      let(:resource) { template["Resources"]["SecretRedshiftMasterUser"] }
+
+      it "is of type AWS::SecretsManager::Secret" do
+          expect(resource["Type"]).to eq("AWS::SecretsManager::Secret")
+      end
+      
+      it "to have property Description" do
+          expect(resource["Properties"]["Description"]).to eq({"Fn::Sub"=>"${EnvironmentName} Secrets Manager to store Redshift user credentials"})
+      end
+      
+      it "to have property GenerateSecretString" do
+          expect(resource["Properties"]["GenerateSecretString"]).to eq({"SecretStringTemplate"=>{"Fn::Sub"=>"{\"username\": \"${MasterUsername}\"}"}, "GenerateStringKey"=>"password", "PasswordLength"=>32, "ExcludePunctuation"=>true})
+      end
+      
+    end
+    
+    context "SecretTargetAttachment" do
+      let(:resource) { template["Resources"]["SecretTargetAttachment"] }
+
+      it "is of type AWS::SecretsManager::SecretTargetAttachment" do
+          expect(resource["Type"]).to eq("AWS::SecretsManager::SecretTargetAttachment")
+      end
+      
+      it "to have property SecretId" do
+          expect(resource["Properties"]["SecretId"]).to eq({"Ref"=>"SecretRedshiftMasterUser"})
+      end
+      
+      it "to have property TargetId" do
+          expect(resource["Properties"]["TargetId"]).to eq({"Ref"=>"RedshiftCluster"})
+      end
+      
+      it "to have property TargetType" do
+          expect(resource["Properties"]["TargetType"]).to eq("AWS::Redshift::Cluster")
+      end
+      
+    end
+    
+    context "RedshiftClusterSubnetGroup" do
+      let(:resource) { template["Resources"]["RedshiftClusterSubnetGroup"] }
+
+      it "is of type AWS::Redshift::ClusterSubnetGroup" do
+          expect(resource["Type"]).to eq("AWS::Redshift::ClusterSubnetGroup")
+      end
+      
+      it "to have property Description" do
+          expect(resource["Properties"]["Description"]).to eq({"Fn::Sub"=>"${EnvironmentName} - Redshift cluster subnet group"})
+      end
+      
+      it "to have property SubnetIds" do
+          expect(resource["Properties"]["SubnetIds"]).to eq({"Ref"=>"SubnetIds"})
+      end
+      
+      it "to have property Tags" do
+          expect(resource["Properties"]["Tags"]).to eq([{"Key"=>"Environment", "Value"=>{"Ref"=>"EnvironmentName"}}])
+      end
+      
+    end
+    
+    context "RedshiftClusterParameterGroup" do
+      let(:resource) { template["Resources"]["RedshiftClusterParameterGroup"] }
+
+      it "is of type AWS::Redshift::ClusterParameterGroup" do
+          expect(resource["Type"]).to eq("AWS::Redshift::ClusterParameterGroup")
+      end
+      
+      it "to have property Description" do
+          expect(resource["Properties"]["Description"]).to eq({"Fn::Sub"=>"${EnvironmentName} - Redshift cluster parameter group"})
+      end
+      
+      it "to have property ParameterGroupFamily" do
+          expect(resource["Properties"]["ParameterGroupFamily"]).to eq("redshift-1.0")
+      end
+      
+      it "to have property Parameters" do
+          expect(resource["Properties"]["Parameters"]).to eq([{"ParameterName"=>"enable_user_activity_logging", "ParameterValue"=>"true"}])
+      end
+      
+      it "to have property Tags" do
+          expect(resource["Properties"]["Tags"]).to eq([{"Key"=>"Environment", "Value"=>{"Ref"=>"EnvironmentName"}}])
+      end
+      
+    end
+    
+    context "RedshiftCluster" do
+      let(:resource) { template["Resources"]["RedshiftCluster"] }
+
+      it "is of type AWS::Redshift::Cluster" do
+          expect(resource["Type"]).to eq("AWS::Redshift::Cluster")
+      end
+      
+      it "to have property ClusterType" do
+          expect(resource["Properties"]["ClusterType"]).to eq({"Fn::If"=>["RedshiftSingleNodeClusterCondition", "single-node", "multi-node"]})
+      end
+      
+      it "to have property NumberOfNodes" do
+          expect(resource["Properties"]["NumberOfNodes"]).to eq({"Fn::If"=>["RedshiftSingleNodeClusterCondition", {"Ref"=>"AWS::NoValue"}, {"Ref"=>"NumberOfNodes"}]})
+      end
+      
+      it "to have property Encrypted" do
+          expect(resource["Properties"]["Encrypted"]).to eq({"Ref"=>"Encrypt"})
+      end
+      
+      it "to have property KmsKeyId" do
+          expect(resource["Properties"]["KmsKeyId"]).to eq({"Fn::If"=>["EncryptWithKMS", {"Ref"=>"KmsKeyId"}, {"Ref"=>"AWS::NoValue"}]})
+      end
+      
+      it "to have property NodeType" do
+          expect(resource["Properties"]["NodeType"]).to eq({"Ref"=>"NodeType"})
+      end
+      
+      it "to have property DBName" do
+          expect(resource["Properties"]["DBName"]).to eq({"Fn::If"=>["DatabaseNameSet", {"Ref"=>"DatabaseName"}, {"Ref"=>"AWS::NoValue"}]})
+      end
+      
+      it "to have property PubliclyAccessible" do
+          expect(resource["Properties"]["PubliclyAccessible"]).to eq(false)
+      end
+      
+      it "to have property MasterUsername" do
+          expect(resource["Properties"]["MasterUsername"]).to eq({"Fn::Sub"=>"{{resolve:secretsmanager:${SecretRedshiftMasterUser}:SecretString:username}}"})
+      end
+      
+      it "to have property MasterUserPassword" do
+          expect(resource["Properties"]["MasterUserPassword"]).to eq({"Fn::Sub"=>"{{resolve:secretsmanager:${SecretRedshiftMasterUser}:SecretString:password}}"})
+      end
+      
+      it "to have property ClusterParameterGroupName" do
+          expect(resource["Properties"]["ClusterParameterGroupName"]).to eq({"Ref"=>"RedshiftClusterParameterGroup"})
+      end
+      
+      it "to have property ClusterSubnetGroupName" do
+          expect(resource["Properties"]["ClusterSubnetGroupName"]).to eq({"Ref"=>"RedshiftClusterSubnetGroup"})
+      end
+      
+      it "to have property VpcSecurityGroupIds" do
+          expect(resource["Properties"]["VpcSecurityGroupIds"]).to eq([{"Ref"=>"RedshiftSecurityGroup"}])
+      end
+      
+      it "to have property AutomatedSnapshotRetentionPeriod" do
+          expect(resource["Properties"]["AutomatedSnapshotRetentionPeriod"]).to eq({"Ref"=>"AutomatedSnapshotRetentionPeriod"})
+      end
+      
+      it "to have property PreferredMaintenanceWindow" do
+          expect(resource["Properties"]["PreferredMaintenanceWindow"]).to eq({"Ref"=>"MaintenanceWindow"})
+      end
+      
+      it "to have property LoggingProperties" do
+          expect(resource["Properties"]["LoggingProperties"]).to eq({"Fn::If"=>["EnableLoggingCondition", {"BucketName"=>{"Ref"=>"RedshiftLoggingS3Bucket"}, "S3KeyPrefix"=>"AWSLogs"}, {"Ref"=>"AWS::NoValue"}]})
+      end
+      
+      it "to have property IamRoles" do
+          expect(resource["Properties"]["IamRoles"]).to eq([{"Fn::GetAtt"=>["RedshiftIAMRole", "Arn"]}, {"Fn::GetAtt"=>["a", "Arn"]}, {"Fn::GetAtt"=>["b", "Arn"]}])
+      end
+      
+      it "to have property SnapshotIdentifier" do
+          expect(resource["Properties"]["SnapshotIdentifier"]).to eq({"Fn::If"=>["SnapshotSet", {"Ref"=>"Snapshot"}, {"Ref"=>"AWS::NoValue"}]})
+      end
+      
+      it "to have property OwnerAccount" do
+          expect(resource["Properties"]["OwnerAccount"]).to eq({"Fn::If"=>["SnapshotAccountOwnerSet", {"Ref"=>"SnapshotAccountOwner"}, {"Ref"=>"AWS::NoValue"}]})
+      end
+      
+      it "to have property Tags" do
+          expect(resource["Properties"]["Tags"]).to eq([{"Key"=>"Environment", "Value"=>{"Ref"=>"EnvironmentName"}}])
+      end
+      
+    end
+    
+  end
+
+end

--- a/spec/multiple_iam_roles_spec.rb
+++ b/spec/multiple_iam_roles_spec.rb
@@ -88,7 +88,7 @@ describe 'compiled component redshift' do
       end
       
       it "to have property RoleName" do
-          expect(resource["Properties"]["RoleName"]).to eq("dl-uat-RedshiftCopyUnload")
+          expect(resource["Properties"]["RoleName"]).to eq({"Fn::Sub"=>"dl-${EnvironmentName}-RedshiftCopyUnload"})
       end
       
     end

--- a/tests/multiple_iam_roles.test.yaml
+++ b/tests/multiple_iam_roles.test.yaml
@@ -9,15 +9,17 @@ iam_policies:
     logs:
       action:
         - logs:*
-  a:
+  RedshiftCopyUnload:
     logs:
       action:
         - logs:*
-  b:
+  MyOtherRole:
     logs:
       action:
         - logs:*
 
 additional_iam_roles:
-- a
-- b
+  RedshiftCopyUnload:
+    name: dl-uat-RedshiftCopyUnload
+  MyOtherRole:
+    name: myotherrole

--- a/tests/multiple_iam_roles.test.yaml
+++ b/tests/multiple_iam_roles.test.yaml
@@ -22,4 +22,4 @@ additional_iam_roles:
   RedshiftCopyUnload:
     name: dl-uat-RedshiftCopyUnload
   MyOtherRole:
-    name: myotherrole
+  

--- a/tests/multiple_iam_roles.test.yaml
+++ b/tests/multiple_iam_roles.test.yaml
@@ -1,0 +1,23 @@
+test_metadata:
+  type: config
+  name: multiple_iam_roles
+  description: set the description for your test
+
+# Insert your tests here
+iam_policies:
+  redshift:
+    logs:
+      action:
+        - logs:*
+  a:
+    logs:
+      action:
+        - logs:*
+  b:
+    logs:
+      action:
+        - logs:*
+
+additional_iam_roles:
+- a
+- b

--- a/tests/multiple_iam_roles.test.yaml
+++ b/tests/multiple_iam_roles.test.yaml
@@ -20,6 +20,6 @@ iam_policies:
 
 additional_iam_roles:
   RedshiftCopyUnload:
-    name: dl-uat-RedshiftCopyUnload
+    name: 'dl-${EnvironmentName}-RedshiftCopyUnload'
   MyOtherRole:
   


### PR DESCRIPTION
feature: add the ability to create and attach multiple iam roles to the redshift cluster

discussion: https://base2services.slack.com/archives/C04NJ1UC65D/p1694145435970139?thread_ts=1694061979.886639&cid=C04NJ1UC65D

# Test1 (on create):
<img width="423" alt="Screenshot 2023-09-09 at 6 17 10 pm" src="https://github.com/theonestack/hl-component-redshift/assets/26110206/24c9bbcd-0ce9-4f6e-b3b3-c033cdaa8811">
<img width="709" alt="Screenshot 2023-09-09 at 6 15 13 pm" src="https://github.com/theonestack/hl-component-redshift/assets/26110206/b020224b-8c06-412b-8779-7ced3e44ae59">
<img width="597" alt="Screenshot 2023-09-09 at 6 16 12 pm" src="https://github.com/theonestack/hl-component-redshift/assets/26110206/c3af5f77-95ba-434b-afb1-0b0c34ef252c">
<img width="648" alt="Screenshot 2023-09-09 at 6 16 30 pm" src="https://github.com/theonestack/hl-component-redshift/assets/26110206/a4445bc0-ec71-43e9-bff3-96466812ab69">
<img width="618" alt="Screenshot 2023-09-09 at 6 16 38 pm" src="https://github.com/theonestack/hl-component-redshift/assets/26110206/56b741eb-9e6b-4588-ae6b-03b68b44df46">
<img width="804" alt="Screenshot 2023-09-09 at 6 16 50 pm" src="https://github.com/theonestack/hl-component-redshift/assets/26110206/9924c73c-bcd8-4977-93e0-dfc7a82061f4">
<img width="804" alt="Screenshot" src="https://github.com/theonestack/hl-component-redshift/assets/26110206/beccca40-7742-4d62-a89f-21da830e69c3">






# Test2 (on update existing cluster with 1 default iam role already exists)
<img width="1440" alt="update1" src="https://github.com/theonestack/hl-component-redshift/assets/26110206/1258608a-7c03-4d85-be2e-3b5fea220483">
<img width="1440" alt="update2" src="https://github.com/theonestack/hl-component-redshift/assets/26110206/28c15d90-44d9-484b-85e8-4772181188fd">

